### PR TITLE
Recursion in horizon/scoreboard

### DIFF
--- a/horizon/scoreboard/scoreboard_c.lua
+++ b/horizon/scoreboard/scoreboard_c.lua
@@ -60,7 +60,7 @@ end
 AddEvent("OnKeyRelease", OnKeyRelease)
 
 function UpdateScoreboardData()
-	CallRemoteEvent("scoreboard:update")
+	CallRemoteEvent("scoreboard:getdata")
 end
 
 function OnGetScoreboardData(servername, count, maxplayers, players)

--- a/horizon/scoreboard/scoreboard_s.lua
+++ b/horizon/scoreboard/scoreboard_s.lua
@@ -12,7 +12,7 @@ You should have received a copy of the Onset Open Source License along with this
 see https://bluemountains.io/Onset_OpenSourceSoftware_License.txt
 ]]--
 
-AddRemoteEvent("scoreboard:update", function(player)
+AddRemoteEvent("scoreboard:getdata", function(player)
 	local PlayerTable = { }
 	
 	for _, v in ipairs(GetAllPlayers()) do


### PR DESCRIPTION
When the server starts up, it adds a remote event named `scoreboard:update` and then it calls the same event, essentially re-calling itself, when the player presses `tab` it will only add a recursion to the already running recursions.

This commit fixes this, by splitting the event to two pieces, one that gets the all the online player data on the server side and the second that does the rest on the client side.