### PR TITLE
add loop option

### DIFF
--- a/soundstreamer/soundstreamer_c.lua
+++ b/soundstreamer/soundstreamer_c.lua
@@ -92,7 +92,7 @@ AddEvent("OnObjectStreamIn", function(object)
 		end
 
 		-- Create the actual sound
-		StreamedSounds[object].sound = CreateSound3D(_soundStream.file, x, y, z, _soundStream.radius)
+		StreamedSounds[object].sound = CreateSound3D(_soundStream.file, x, y, z, _soundStream.radius, _soundStream.loop)
 
 		if StreamedSounds[object].sound == false then
 			if IsGameDevMode() then
@@ -142,7 +142,7 @@ AddEvent("OnObjectNetworkUpdatePropertyValue", function(object, PropertyName, Pr
 		if CurrentPV.radius ~= PropertyValue.radius then
 			DestroySound(StreamedSounds[object].sound)
 			local x, y, z = GetObjectLocation(object)
-			StreamedSounds[object].sound = CreateSound3D(StreamedSounds[object].file, x, y, z, PropertyValue.radius)
+			StreamedSounds[object].sound = CreateSound3D(StreamedSounds[object].file, x, y, z, PropertyValue.radius, _soundStream.loop)
 		end
 
 		SetSoundVolume(StreamedSounds[object].sound, PropertyValue.volume)
@@ -190,17 +190,4 @@ AddEvent("OnGameTick", function(DeltaSeconds)
 		end
 	end
 
-end)
-
-AddEvent("OnSoundFinished", function(sound)
-	-- Get the streamedsound according to the sound that just stop
-	for k,v in pairs(StreamedSounds) do
-		if v.sound == sound and v.loop == true then -- If we found it and loop is true
-			local x, y, z = GetObjectLocation(k) -- Get the actual position of the object
-			v.sound = CreateSound3D(v.file, x, y, z, v.radius) -- Start a new sound with same properties
-			SetSoundVolume(v.sound, v.volume)
-			SetSoundPitch(v.sound, v.pitch)
-			return
-		end
-	end
 end)

--- a/soundstreamer/soundstreamer_c.lua
+++ b/soundstreamer/soundstreamer_c.lua
@@ -191,3 +191,16 @@ AddEvent("OnGameTick", function(DeltaSeconds)
 	end
 
 end)
+
+AddEvent("OnSoundFinished", function(sound)
+	-- Get the streamedsound according to the sound that just stop
+	for k,v in pairs(StreamedSounds) do
+		if v.sound == sound and v.loop == true then -- If we found it and loop is true
+			local x, y, z = GetObjectLocation(k) -- Get the actual position of the object
+			v.sound = CreateSound3D(v.file, x, y, z, v.radius) -- Start a new sound with same properties
+			SetSoundVolume(v.sound, v.volume)
+			SetSoundPitch(v.sound, v.pitch)
+			return
+		end
+	end
+end)

--- a/soundstreamer/soundstreamer_s.lua
+++ b/soundstreamer/soundstreamer_s.lua
@@ -24,7 +24,7 @@ AddEvent("OnPackageStop", function()
 
 end)
 
-AddFunctionExport("CreateSound3D", function (sound_file, x, y, z, radius, volume, pitch)
+AddFunctionExport("CreateSound3D", function (sound_file, x, y, z, radius, volume, pitch, bLoop)
 
 	if sound_file == nil or x == nil or y == nil or z == nil then
 		return false
@@ -49,6 +49,7 @@ AddFunctionExport("CreateSound3D", function (sound_file, x, y, z, radius, volume
 	_soundStream.radius = radius
 	_soundStream.volume = volume
 	_soundStream.pitch = pitch
+	_soundStream.loop = bLoop
 
 	SetObjectPropertyValue(object, "_soundStream", _soundStream)
 
@@ -57,7 +58,7 @@ AddFunctionExport("CreateSound3D", function (sound_file, x, y, z, radius, volume
 	return object
 end)
 
-AddFunctionExport("CreateAttachedSound3D", function(attach, id, sound_file, radius, volume, pitch)
+AddFunctionExport("CreateAttachedSound3D", function(attach, id, sound_file, radius, volume, pitch, bLoop)
 
 	if attach == nil or id == nil or sound_file == nil then
 		return false
@@ -81,6 +82,7 @@ AddFunctionExport("CreateAttachedSound3D", function(attach, id, sound_file, radi
 	_soundStream.radius = radius
 	_soundStream.volume = volume
 	_soundStream.pitch = pitch
+	_soundStream.loop = bLoop
 
 	SetObjectPropertyValue(object, "_soundStream", _soundStream)
 

--- a/soundstreamer/soundstreamer_s.lua
+++ b/soundstreamer/soundstreamer_s.lua
@@ -33,6 +33,7 @@ AddFunctionExport("CreateSound3D", function (sound_file, x, y, z, radius, volume
 	radius = radius or 2500.0
 	volume = volume or 1.0
 	pitch = pitch or 1.0
+	bLoop = bLoop or false
 
 	-- Create a dummy object that will help us streaming the sound
 	local object = CreateObject(1, x, y, z)
@@ -67,6 +68,7 @@ AddFunctionExport("CreateAttachedSound3D", function(attach, id, sound_file, radi
 	radius = radius or 2500.0
 	volume = volume or 1.0
 	pitch = pitch or 1.0
+	bLoop = bLoop or false
 
 	local object = CreateObject(1, 0.0, 0.0, 0.0)
 	


### PR DESCRIPTION
A tweak to allow people to auto loop sounds by adding `bLoop` param to `CreateSound3D` and `CreateAttachedSound3D` functions.

NB : Loop on CreateSound is added in 1.2.2 version of Onset