### PR TITLE
Exit console command fix

### DIFF
--- a/default/ConsoleFunctions_s.lua
+++ b/default/ConsoleFunctions_s.lua
@@ -102,6 +102,10 @@ AddConsoleCommand("list", "List all started packages", function()
 	end
 end)
 
-AddConsoleCommand("exit", "Stops the server", function(reason)
-	ServerExit(reason)
+AddConsoleCommand("exit", "Stops the server", function(...)
+	if ... then
+		ServerExit(table.concat({...}, " "))
+	else
+		ServerExit()
+	end
 end)


### PR DESCRIPTION
Error:
`[string "default/ConsoleFunctions_s.lua"]:106: bad argument #1 to 'ServerExit' (expected string-like argument)`

This also supports for multiple word exit reason